### PR TITLE
Refactor launcher command handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bluetooth: use alias instead of name for device name
 - Airplane button fail when the `rfkill` returns an error or is not present
 
+## [0.2.2] - 2025-09-27
+
+### Changed
+
+- Launcher commands now execute via Tokio, logging failures instead of panicking and exposing a reusable async API for command status and output retrieval.
+
+### Fixed
+
+- Fire-and-forget power actions no longer abort the process on spawn failures or non-zero exit codes.
+
 ## [0.2.1] - 2025-09-26
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hydebar"
 description = "A ready to go Wayland status bar for Hyprland"
 homepage = "https://github.com/MalpenZibo/hydebar"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 rust-version = "1.90"
 

--- a/src/utils/launcher.rs
+++ b/src/utils/launcher.rs
@@ -1,56 +1,231 @@
-use std::process::Command;
+use std::{
+    process::{ExitStatus, Output},
+    sync::Arc,
+};
 
+use log::error;
+use masterror::Error;
+use tokio::process::Command;
+
+/// Error type emitted when launching shell commands fails.
+///
+/// The error keeps a shared reference to the original command string so callers can
+/// differentiate failures per command without cloning large buffers.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::sync::Arc;
+///
+/// use hydebar::utils::launcher::{
+///     run_shell_command,
+///     CommandCapture,
+///     CommandOutcome,
+/// };
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let runtime = tokio::runtime::Runtime::new()?;
+/// let command = Arc::from("true");
+/// runtime.block_on(async move {
+///     match run_shell_command(&command, CommandCapture::Status).await? {
+///         CommandOutcome::Status(status) => {
+///             assert!(status.success());
+///         }
+///         CommandOutcome::Output(_) => unreachable!(),
+///     }
+///     Ok::<(), hydebar::utils::launcher::LauncherError>(())
+/// })?;
+/// Ok(())
+/// # }
+/// ```
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum LauncherError {
+    /// The command could not be spawned by the operating system.
+    #[error("failed to spawn `{command}`: {context}")]
+    Spawn {
+        /// The attempted command string.
+        command: Arc<str>,
+        /// Additional context provided by the OS error.
+        context: Arc<str>,
+    },
+    /// The command executed but returned a non-zero exit status.
+    #[error("command `{command}` exited with status {status}")]
+    NonZeroExit {
+        /// The attempted command string.
+        command: Arc<str>,
+        /// The exit status returned by the process.
+        status: ExitStatus,
+    },
+}
+
+impl LauncherError {
+    fn spawn_error(command: Arc<str>, error: std::io::Error) -> Self {
+        Self::Spawn {
+            command,
+            context: Arc::from(error.to_string()),
+        }
+    }
+
+    fn exit_error(command: Arc<str>, status: ExitStatus) -> Self {
+        Self::NonZeroExit { command, status }
+    }
+}
+
+/// Determines whether the launcher should observe only the exit status or capture full
+/// output of the executed command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandCapture {
+    /// Await only the process exit status.
+    Status,
+    /// Capture stdout and stderr alongside the exit status.
+    Output,
+}
+
+/// Outcome of a launched command depending on the capture mode requested.
+#[derive(Debug)]
+pub enum CommandOutcome {
+    /// Process exit status when [`CommandCapture::Status`] was requested.
+    Status(ExitStatus),
+    /// Full process output when [`CommandCapture::Output`] was requested.
+    Output(Output),
+}
+
+/// Launch `bash -c <command>` asynchronously using Tokio and return the observed result.
+///
+/// The function reuses a shared command string across errors to avoid unnecessary
+/// allocations and reports non-zero exit codes as [`LauncherError::NonZeroExit`].
+///
+/// # Errors
+///
+/// Returns [`LauncherError::Spawn`] if the process cannot be created or
+/// [`LauncherError::NonZeroExit`] when the command finishes unsuccessfully.
+pub async fn run_shell_command(
+    command: &Arc<str>,
+    capture: CommandCapture,
+) -> Result<CommandOutcome, LauncherError> {
+    let mut process = Command::new("bash");
+    process.arg("-c").arg(command.as_ref());
+
+    match capture {
+        CommandCapture::Status => {
+            let status = process
+                .status()
+                .await
+                .map_err(|error| LauncherError::spawn_error(command.clone(), error))?;
+
+            if status.success() {
+                Ok(CommandOutcome::Status(status))
+            } else {
+                Err(LauncherError::exit_error(command.clone(), status))
+            }
+        }
+        CommandCapture::Output => {
+            let output = process
+                .output()
+                .await
+                .map_err(|error| LauncherError::spawn_error(command.clone(), error))?;
+
+            if output.status.success() {
+                Ok(CommandOutcome::Output(output))
+            } else {
+                Err(LauncherError::exit_error(command.clone(), output.status))
+            }
+        }
+    }
+}
+
+fn spawn_and_log(command: String, context: &'static str) {
+    tokio::spawn(async move {
+        let command_arc: Arc<str> = Arc::from(command);
+        if let Err(error) = run_shell_command(&command_arc, CommandCapture::Status).await {
+            error!("{context} command failed: {error}");
+        }
+    });
+}
+
+/// Execute an arbitrary shell command without awaiting its completion.
+///
+/// The command is executed in a background Tokio task to preserve the fire-and-forget
+/// semantics used throughout the UI.
+///
+/// # Examples
+///
+/// ```no_run
+/// use hydebar::utils::launcher;
+///
+/// launcher::execute_command("notify-send hydebar 'Hello'".to_owned());
+/// ```
 pub fn execute_command(command: String) {
-    tokio::spawn(async move {
-        let _ = Command::new("bash")
-            .arg("-c")
-            .arg(&command)
-            .spawn()
-            .unwrap_or_else(|_| panic!("Failed to execute command {}", &command))
-            .wait();
-    });
+    spawn_and_log(command, "launcher");
 }
 
-pub fn suspend(cmd: String) {
-    tokio::spawn(async move {
-        let _ = Command::new("bash")
-            .arg("-c")
-            .arg(cmd)
-            .spawn()
-            .expect("Failed to execute command.")
-            .wait();
-    });
+/// Execute the configured suspend command in the background.
+pub fn suspend(command: String) {
+    spawn_and_log(command, "suspend");
 }
 
-pub fn shutdown(cmd: String) {
-    tokio::spawn(async move {
-        let _ = Command::new("bash")
-            .arg("-c")
-            .arg(cmd)
-            .spawn()
-            .expect("Failed to execute command.")
-            .wait();
-    });
+/// Execute the configured shutdown command in the background.
+pub fn shutdown(command: String) {
+    spawn_and_log(command, "shutdown");
 }
 
-pub fn reboot(cmd: String) {
-    tokio::spawn(async move {
-        let _ = Command::new("bash")
-            .arg("-c")
-            .arg(cmd)
-            .spawn()
-            .expect("Failed to execute command.")
-            .wait();
-    });
+/// Execute the configured reboot command in the background.
+pub fn reboot(command: String) {
+    spawn_and_log(command, "reboot");
 }
 
-pub fn logout(cmd: String) {
-    tokio::spawn(async move {
-        let _ = Command::new("bash")
-            .arg("-c")
-            .arg(cmd)
-            .spawn()
-            .expect("Failed to execute command.")
-            .wait();
-    });
+/// Execute the configured logout command in the background.
+pub fn logout(command: String) {
+    spawn_and_log(command, "logout");
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use super::{CommandCapture, CommandOutcome, LauncherError, run_shell_command};
+
+    #[tokio::test]
+    async fn reports_successful_status() -> Result<(), Box<dyn std::error::Error>> {
+        let command = Arc::from("true");
+
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(5),
+            run_shell_command(&command, CommandCapture::Status),
+        )
+        .await?;
+
+        let status = match outcome? {
+            CommandOutcome::Status(status) => status,
+            CommandOutcome::Output(_) => {
+                return Err("status capture expected".into());
+            }
+        };
+
+        assert!(status.success());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn reports_non_zero_exit_as_error() -> Result<(), Box<dyn std::error::Error>> {
+        let command = Arc::from("exit 42");
+
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(5),
+            run_shell_command(&command, CommandCapture::Status),
+        )
+        .await?;
+
+        match outcome {
+            Err(LauncherError::NonZeroExit { status, .. }) => {
+                assert_eq!(status.code(), Some(42));
+            }
+            other => {
+                return Err(format!("unexpected outcome: {other:?}").into());
+            }
+        }
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary
- replace the launcher helpers with a shared async Tokio runner that surfaces typed errors
- keep power-menu commands fire-and-forget while logging failures instead of panicking and add async coverage
- bump the crate to 0.2.2 and document the launcher changes in the changelog

## Testing
- `cargo +nightly fmt --`
- `cargo +nightly clippy -- -D warnings` *(fails: build breaks in pre-existing pipewire privacy service code)*
- `cargo +nightly build --all-targets` *(fails: same pipewire compile error)*
- `cargo +nightly test --all` *(aborted: compilation hits same pipewire error)*
- `cargo +nightly doc --no-deps`
- `cargo audit`
- `cargo deny check` *(fails: unable to fetch advisory database)*

------
https://chatgpt.com/codex/tasks/task_e_68d6188d561c832b924f305cac92f0fb