### PR TITLE
Improve configuration and channel error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add custom commands for power menu actions
 - Add battery module with configurable power-profile indicator and fallback view
 
+## [0.3.2] - 2025-09-26
+
+### Changed
+
+- Return typed errors from the configuration loader and application entrypoint to avoid process aborts.
+- Handle channel backpressure gracefully across runtime modules, logging and skipping events instead of panicking.
+
+### Fixed
+
+- Added regression tests covering configuration read failures and channel send errors to ensure the application remains stable.
+
 ## [0.3.1] - 2025-09-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-app"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap",
  "flexi_logger",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2300,6 +2300,8 @@ dependencies = [
  "serde_with",
  "shellexpand",
  "sysinfo",
+ "tempfile",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "toml 0.9.7",
@@ -2312,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-gui"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "flexi_logger",
  "hydebar-core",
@@ -2324,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-proto"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "hex_color",
  "iced",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 rust-version = "1.90"
 

--- a/crates/hydebar-app/src/main.rs
+++ b/crates/hydebar-app/src/main.rs
@@ -7,7 +7,10 @@ use clap::{Parser, command};
 use flexi_logger::{
     Age, Cleanup, Criterion, FileSpec, LogSpecBuilder, LogSpecification, Logger, Naming,
 };
-use hydebar_core::{adapters::hyprland_client::HyprlandClient, config::get_config};
+use hydebar_core::{
+    adapters::hyprland_client::HyprlandClient,
+    config::{ConfigLoadError, get_config},
+};
 use hydebar_gui::{App, get_log_spec};
 use hydebar_proto::ports::hyprland::HyprlandPort;
 use iced::Font;
@@ -15,6 +18,7 @@ use log::{debug, error};
 use std::panic;
 use std::path::PathBuf;
 use std::{backtrace::Backtrace, borrow::Cow, sync::Arc};
+use thiserror::Error;
 
 const ICON_FONT: &[u8] = include_bytes!("../../assets/SymbolsNerdFont-Regular.ttf");
 
@@ -25,8 +29,22 @@ struct Args {
     config_path: Option<PathBuf>,
 }
 
+#[derive(Debug, Error)]
+enum MainError {
+    #[error("failed to initialize logger: {0}")]
+    Logger(#[from] flexi_logger::FlexiLoggerError),
+    #[error("configuration error: {0}")]
+    Config(#[from] ConfigLoadError),
+    #[error("iced runtime error: {0}")]
+    Iced(#[from] iced::Error),
+}
+
 #[tokio::main]
-async fn main() -> iced::Result {
+async fn main() -> Result<(), MainError> {
+    run().await
+}
+
+async fn run() -> Result<(), MainError> {
     let args = Args::parse();
     debug!("args: {args:?}");
 
@@ -47,19 +65,15 @@ async fn main() -> iced::Result {
     } else {
         logger
     };
-    let logger = logger.start().unwrap();
+    let logger = logger.start()?;
     panic::set_hook(Box::new(|info| {
         let b = Backtrace::capture();
         error!("Panic: {info} \n {b}");
     }));
 
-    let (config, config_path) = get_config(args.config_path).unwrap_or_else(|err| {
-        error!("Failed to read config: {err}");
+    let (config, config_path) = get_config(args.config_path)?;
 
-        std::process::exit(1);
-    });
-
-    logger.set_new_spec(get_log_spec(&config.log_level));
+    logger.set_new_spec(get_log_spec(&config.log_level))?;
 
     let font = match config.appearance.font_name {
         Some(ref font_name) => Font::with_name(Box::leak(font_name.clone().into_boxed_str())),
@@ -76,4 +90,5 @@ async fn main() -> iced::Result {
         .font(Cow::from(ICON_FONT))
         .default_font(font)
         .run_with(App::new((logger, config, config_path, hyprland)))
+        .map_err(MainError::from)
 }

--- a/crates/hydebar-core/Cargo.toml
+++ b/crates/hydebar-core/Cargo.toml
@@ -32,3 +32,7 @@ uuid.workspace = true
 wayland-client.workspace = true
 wayland-protocols.workspace = true
 zbus.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+tempfile = "3"


### PR DESCRIPTION
## Summary
- replace fallible configuration loading with typed errors, default fallbacks, and regression tests
- guard the updates module against channel backpressure and add coverage for enqueue failures
- propagate typed errors from the application entrypoint and bump the workspace version to 0.3.2

## Testing
- cargo +nightly fmt --
- cargo +1.90.0 build --all-targets *(fails: existing hyprland adapter compilation errors)*
- cargo +1.90.0 test --workspace --all *(fails: existing unresolved imports in core modules)*
- cargo +1.90.0 clippy --workspace -D warnings *(fails: existing hyprland adapter compilation errors)*
- cargo +1.90.0 doc --no-deps *(fails: existing type inference errors in modules)*
- cargo audit *(installation requires lengthy dependency build; aborted due to time constraints)*
- cargo deny *(not run; tool not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d659182d38832b976c319c8509dca2