### PR TITLE
Improve config reload reliability and partial updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add custom commands for power menu actions
 - Add battery module with configurable power-profile indicator and fallback view
 
+## [0.3.3] - 2025-09-26
+
+### Changed
+
+- Guard configuration reloads behind a stateful manager that keeps the last valid settings and computes module-level impact before updates.
+- Emit degradation events to the GUI instead of reverting to defaults when config files are removed or invalid.
+
+### Added
+
+- Added validation for custom module definitions and layout references during config reloads.
+- Delivered partial reload support that refreshes outputs and custom modules only when their config changes.
+- Extended configuration watcher tests to cover valid reloads, invalid TOML, and file removal without panics.
+
 ## [0.3.2] - 2025-09-26
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-app"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "clap",
  "flexi_logger",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-core"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2314,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-gui"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "flexi_logger",
  "hydebar-core",
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "hydebar-proto"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "hex_color",
  "iced",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 rust-version = "1.90"
 

--- a/crates/hydebar-app/src/main.rs
+++ b/crates/hydebar-app/src/main.rs
@@ -9,7 +9,7 @@ use flexi_logger::{
 };
 use hydebar_core::{
     adapters::hyprland_client::HyprlandClient,
-    config::{ConfigLoadError, get_config},
+    config::{ConfigLoadError, ConfigManager, get_config},
 };
 use hydebar_gui::{App, get_log_spec};
 use hydebar_proto::ports::hyprland::HyprlandPort;
@@ -72,6 +72,7 @@ async fn run() -> Result<(), MainError> {
     }));
 
     let (config, config_path) = get_config(args.config_path)?;
+    let config_manager = Arc::new(ConfigManager::new(config.clone()));
 
     logger.set_new_spec(get_log_spec(&config.log_level))?;
 
@@ -89,6 +90,12 @@ async fn run() -> Result<(), MainError> {
         .scale_factor(App::scale_factor)
         .font(Cow::from(ICON_FONT))
         .default_font(font)
-        .run_with(App::new((logger, config, config_path, hyprland)))
+        .run_with(App::new((
+            logger,
+            config,
+            config_manager,
+            config_path,
+            hyprland,
+        )))
         .map_err(MainError::from)
 }

--- a/crates/hydebar-core/src/config.rs
+++ b/crates/hydebar-core/src/config.rs
@@ -1,22 +1,19 @@
 use std::fs::{self, File};
+use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::{
-    any::TypeId,
-    ffi::{OsStr, OsString},
-    fmt::Display,
-    future::Future,
-    io::Read,
-    pin::Pin,
-};
 
 pub use hydebar_proto::config::*;
 
-use hydebar_proto::config::{Config, DEFAULT_CONFIG_FILE_PATH};
-use iced::futures::channel::mpsc::{SendError, Sender};
-use iced::futures::{SinkExt, Stream, StreamExt, pin_mut};
-use iced::{Subscription, stream::channel};
-use inotify::{EventMask, Inotify, WatchMask};
-use log::{debug, error, info, warn};
+pub mod manager;
+pub mod watch;
+
+pub use manager::{
+    ConfigApplied, ConfigDegradation, ConfigImpact, ConfigManager, ConfigUpdateError,
+};
+pub use watch::{ConfigEvent, subscription};
+
+use hydebar_proto::config::{Config, ConfigValidationError, DEFAULT_CONFIG_FILE_PATH};
+use log::{info, warn};
 use shellexpand::full;
 use thiserror::Error;
 
@@ -46,7 +43,7 @@ pub enum ConfigLoadError {
 }
 
 #[derive(Debug, Error)]
-enum ConfigReadError {
+pub(crate) enum ConfigReadError {
     #[error("failed to read config file '{path}': {source}")]
     Read {
         path: PathBuf,
@@ -111,7 +108,7 @@ fn ensure_parent_exists(path: &Path) -> Result<(), ConfigLoadError> {
     Ok(())
 }
 
-fn read_config(path: &Path) -> Result<Config, ConfigReadError> {
+pub(crate) fn read_config(path: &Path) -> Result<Config, ConfigReadError> {
     let mut content = String::new();
     File::open(path)
         .and_then(|mut file| file.read_to_string(&mut content))
@@ -130,10 +127,17 @@ fn load_config_or_default(path: &Path) -> Config {
     info!("Decoding config file {path:?}");
 
     match read_config(path) {
-        Ok(config) => {
-            info!("Config file loaded successfully");
-            config
-        }
+        Ok(config) => match config.validate() {
+            Ok(()) => {
+                info!("Config file loaded successfully");
+                config
+            }
+            Err(err) => {
+                warn!("{err}");
+                warn!("Falling back to default configuration");
+                Config::default()
+            }
+        },
         Err(err) => {
             warn!("{err}");
             warn!("Falling back to default configuration");
@@ -176,209 +180,4 @@ mod tests {
             other => panic!("unexpected error: {other:?}"),
         }
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Event {
-    Changed,
-    Removed,
-}
-
-trait WatchedEvent {
-    fn file_name(&self) -> Option<&OsStr>;
-
-    fn mask(&self) -> EventMask;
-}
-
-impl WatchedEvent for inotify::Event<OsString> {
-    fn file_name(&self) -> Option<&OsStr> {
-        self.name.as_deref()
-    }
-
-    fn mask(&self) -> EventMask {
-        self.mask
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum WatchLoopOutcome {
-    StreamEnded,
-    HandlerClosed,
-}
-
-fn interpret_event<E: WatchedEvent>(event: &E, target_name: &OsStr) -> Option<Event> {
-    let name = event.file_name()?;
-
-    if name != target_name {
-        return None;
-    }
-
-    let mask = event.mask();
-
-    if mask == EventMask::DELETE | EventMask::MOVED_FROM {
-        debug!("File deleted or moved");
-        Some(Event::Removed)
-    } else if mask == EventMask::CREATE | EventMask::MODIFY | EventMask::MOVED_TO {
-        debug!("File created or moved");
-        Some(Event::Changed)
-    } else {
-        None
-    }
-}
-
-async fn process_event_batches<S, E, Err, F, Fut, HandlerErr>(
-    mut stream: Pin<&mut S>,
-    target_name: &OsStr,
-    mut handler: F,
-) -> WatchLoopOutcome
-where
-    S: Stream<Item = Vec<Result<E, Err>>>,
-    E: WatchedEvent + std::fmt::Debug,
-    Err: Display,
-    F: FnMut(Event) -> Fut,
-    Fut: Future<Output = Result<(), HandlerErr>>,
-    HandlerErr: Display,
-{
-    while let Some(batch) = stream.as_mut().next().await {
-        let mut file_event = None;
-
-        for event in batch {
-            match event {
-                Ok(event) => {
-                    debug!("Event: {event:?}");
-
-                    match interpret_event(&event, target_name) {
-                        Some(kind) => {
-                            file_event = Some(kind);
-                        }
-                        None => {
-                            debug!("Ignoring event");
-                        }
-                    }
-                }
-                Err(err) => {
-                    error!("Failed to read watch event: {err}");
-                }
-            }
-        }
-
-        if let Some(kind) = file_event {
-            if let Err(err) = handler(kind).await {
-                warn!("Stopping config watch because handler returned an error: {err}");
-                return WatchLoopOutcome::HandlerClosed;
-            }
-        } else {
-            debug!("No relevant file event detected.");
-        }
-    }
-
-    WatchLoopOutcome::StreamEnded
-}
-
-async fn handle_watch_event(
-    output: &mut Sender<ConfigEvent>,
-    path: &Path,
-    event: Event,
-) -> Result<(), SendError> {
-    match event {
-        Event::Changed => {
-            info!("Reload config file");
-
-            let new_config = load_config_or_default(path);
-
-            output
-                .send(ConfigEvent::Updated(Box::new(new_config)))
-                .await
-        }
-        Event::Removed => {
-            info!("Config file removed");
-
-            output.send(ConfigEvent::Updated(Box::default())).await
-        }
-    }
-}
-
-pub fn subscription(path: &Path) -> Subscription<ConfigEvent> {
-    let id = TypeId::of::<Config>();
-    let path = path.to_path_buf();
-
-    Subscription::run_with_id(
-        id,
-        channel(100, move |mut output| async move {
-            let Some(folder) = path.parent().map(Path::to_path_buf) else {
-                error!(
-                    "Config file path does not have a parent directory, cannot watch for changes"
-                );
-                return;
-            };
-
-            let Some(file_name) = path.file_name().map(OsStr::to_os_string) else {
-                error!("Config file path does not have a file name, cannot watch for changes");
-                return;
-            };
-
-            loop {
-                let inotify = match Inotify::init() {
-                    Ok(inotify) => inotify,
-                    Err(e) => {
-                        error!("Failed to initialize inotify: {e}");
-                        break;
-                    }
-                };
-
-                debug!("Watching config file at {path:?}");
-
-                let watch_result = inotify.watches().add(
-                    &folder,
-                    WatchMask::CREATE | WatchMask::DELETE | WatchMask::MOVE | WatchMask::MODIFY,
-                );
-
-                if let Err(e) = watch_result {
-                    error!("Failed to add watch for {folder:?}: {e}");
-                    break;
-                }
-
-                let buffer = [0; 1024];
-                let stream = match inotify.into_event_stream(buffer) {
-                    Ok(stream) => stream,
-                    Err(e) => {
-                        error!("Failed to create inotify event stream: {e}");
-                        break;
-                    }
-                };
-
-                let event_stream = stream.ready_chunks(10);
-                pin_mut!(event_stream);
-
-                let sender_template = output.clone();
-                let path_clone = path.clone();
-
-                match process_event_batches(
-                    event_stream.as_mut(),
-                    file_name.as_os_str(),
-                    move |event| {
-                        let mut sender = sender_template.clone();
-                        let path = path_clone.clone();
-
-                        async move { handle_watch_event(&mut sender, &path, event).await }
-                    },
-                )
-                .await
-                {
-                    WatchLoopOutcome::StreamEnded => {
-                        info!(
-                            "Config watch stream closed; attempting to restart the inotify watcher"
-                        );
-                        continue;
-                    }
-                    WatchLoopOutcome::HandlerClosed => {
-                        info!("Config watch handler closed; stopping watcher loop");
-                        break;
-                    }
-                }
-            }
-
-            info!("Config watcher terminated");
-        }),
-    )
 }

--- a/crates/hydebar-core/src/config/manager.rs
+++ b/crates/hydebar-core/src/config/manager.rs
@@ -1,0 +1,310 @@
+use std::collections::{BTreeSet, HashMap};
+use std::path::PathBuf;
+use std::sync::RwLock;
+
+use hydebar_proto::config::{Config, ConfigValidationError, CustomModuleDef, ModuleName};
+use thiserror::Error;
+
+/// Represents the effect a configuration update has on the running system.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ConfigImpact {
+    /// Modules whose configuration changed and may require additional handling.
+    pub affected_modules: BTreeSet<ModuleName>,
+    /// Whether the module layout changed.
+    pub layout_changed: bool,
+    /// Whether appearance settings changed.
+    pub appearance_changed: bool,
+    /// Whether output targeting changed.
+    pub outputs_changed: bool,
+    /// Whether the bar position changed.
+    pub position_changed: bool,
+    /// Whether the log level changed.
+    pub log_level_changed: bool,
+    /// Whether menu keyboard focus changed.
+    pub menu_focus_changed: bool,
+    /// Whether custom module definitions changed.
+    pub custom_modules_changed: bool,
+}
+
+impl ConfigImpact {
+    /// Returns `true` if the given module is listed as affected by the update.
+    pub fn affects_module(&self, module: &ModuleName) -> bool {
+        self.affected_modules.contains(module)
+    }
+}
+
+/// Applied configuration along with its computed impact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigApplied {
+    /// The fully validated configuration that was applied.
+    pub config: Box<Config>,
+    /// The impact of applying the configuration.
+    pub impact: ConfigImpact,
+}
+
+/// Describes failures that occurred while attempting to refresh the configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ConfigUpdateError {
+    /// Reading the configuration file from disk failed.
+    #[error("failed to read config at {path:?}: {context}")]
+    Read { path: PathBuf, context: String },
+    /// Parsing TOML content failed.
+    #[error("failed to parse config at {path:?}: {context}")]
+    Parse { path: PathBuf, context: String },
+    /// Validation detected a logical inconsistency.
+    #[error(transparent)]
+    Validation(#[from] ConfigValidationError),
+    /// The configuration file was removed.
+    #[error("configuration file removed")]
+    Removed,
+    /// Updating the configuration state failed for an internal reason.
+    #[error("failed to update configuration state: {context}")]
+    State { context: String },
+}
+
+impl ConfigUpdateError {
+    /// Construct a read error with contextual information.
+    pub fn read(path: PathBuf, err: &std::io::Error) -> Self {
+        Self::Read {
+            path,
+            context: err.to_string(),
+        }
+    }
+
+    /// Construct a parse error with contextual information.
+    pub fn parse(path: PathBuf, err: &toml::de::Error) -> Self {
+        Self::Parse {
+            path,
+            context: err.to_string(),
+        }
+    }
+
+    /// Construct a state management error.
+    pub fn state(context: impl Into<String>) -> Self {
+        Self::State {
+            context: context.into(),
+        }
+    }
+}
+
+/// Information about configuration degradation events.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigDegradation {
+    /// The reason the configuration could not be refreshed.
+    pub reason: ConfigUpdateError,
+    /// The last known valid configuration.
+    pub last_valid: Box<Config>,
+}
+
+/// Errors produced by [`ConfigManager`].
+#[derive(Debug, Error)]
+pub enum ConfigManagerError {
+    /// The internal configuration state lock was poisoned.
+    #[error("config state lock poisoned")]
+    Poisoned,
+}
+
+/// Tracks and manages the last known valid configuration.
+#[derive(Debug)]
+pub struct ConfigManager {
+    state: RwLock<Config>,
+}
+
+impl ConfigManager {
+    /// Creates a new manager seeded with the initial configuration.
+    pub fn new(initial: Config) -> Self {
+        Self {
+            state: RwLock::new(initial),
+        }
+    }
+
+    fn with_state<F, T>(&self, f: F) -> Result<T, ConfigManagerError>
+    where
+        F: FnOnce(&Config) -> T,
+    {
+        self.state
+            .read()
+            .map_err(|_| ConfigManagerError::Poisoned)
+            .map(|guard| f(&guard))
+    }
+
+    /// Returns the last successfully applied configuration.
+    pub fn last_valid(&self) -> Result<Config, ConfigManagerError> {
+        self.with_state(Clone::clone)
+    }
+
+    /// Records a degradation event and returns contextual information for consumers.
+    pub fn degraded(
+        &self,
+        reason: ConfigUpdateError,
+    ) -> Result<ConfigDegradation, ConfigManagerError> {
+        self.with_state(|config| ConfigDegradation {
+            reason,
+            last_valid: Box::new(config.clone()),
+        })
+    }
+
+    /// Applies a freshly loaded configuration, computing the impact relative to the previous state.
+    pub fn apply(&self, updated: Config) -> Result<ConfigApplied, ConfigManagerError> {
+        let mut guard = self
+            .state
+            .write()
+            .map_err(|_| ConfigManagerError::Poisoned)?;
+
+        let impact = compute_impact(&*guard, &updated);
+        *guard = updated.clone();
+
+        Ok(ConfigApplied {
+            config: Box::new(updated),
+            impact,
+        })
+    }
+}
+
+fn compute_impact(previous: &Config, next: &Config) -> ConfigImpact {
+    let mut impact = ConfigImpact::default();
+
+    if previous.modules != next.modules {
+        impact.layout_changed = true;
+    }
+
+    if previous.appearance != next.appearance {
+        impact.appearance_changed = true;
+    }
+
+    if previous.appearance.workspace_colors != next.appearance.workspace_colors
+        || previous.appearance.special_workspace_colors != next.appearance.special_workspace_colors
+    {
+        impact.affected_modules.insert(ModuleName::Workspaces);
+    }
+
+    if previous.outputs != next.outputs {
+        impact.outputs_changed = true;
+    }
+
+    if previous.position != next.position {
+        impact.position_changed = true;
+    }
+
+    if previous.log_level != next.log_level {
+        impact.log_level_changed = true;
+    }
+
+    if previous.menu_keyboard_focus != next.menu_keyboard_focus {
+        impact.menu_focus_changed = true;
+    }
+
+    mark_if_changed(
+        &mut impact,
+        ModuleName::AppLauncher,
+        previous.app_launcher_cmd.as_ref(),
+        next.app_launcher_cmd.as_ref(),
+    );
+    mark_if_changed(
+        &mut impact,
+        ModuleName::Clipboard,
+        previous.clipboard_cmd.as_ref(),
+        next.clipboard_cmd.as_ref(),
+    );
+    mark_if_changed(
+        &mut impact,
+        ModuleName::Updates,
+        &previous.updates,
+        &next.updates,
+    );
+    mark_if_changed(
+        &mut impact,
+        ModuleName::Workspaces,
+        &previous.workspaces,
+        &next.workspaces,
+    );
+    mark_if_changed(
+        &mut impact,
+        ModuleName::WindowTitle,
+        &previous.window_title,
+        &next.window_title,
+    );
+    mark_if_changed(
+        &mut impact,
+        ModuleName::SystemInfo,
+        &previous.system,
+        &next.system,
+    );
+    mark_if_changed(
+        &mut impact,
+        ModuleName::Battery,
+        &previous.battery,
+        &next.battery,
+    );
+    mark_if_changed(&mut impact, ModuleName::Clock, &previous.clock, &next.clock);
+    mark_if_changed(
+        &mut impact,
+        ModuleName::Settings,
+        &previous.settings,
+        &next.settings,
+    );
+    mark_if_changed(
+        &mut impact,
+        ModuleName::MediaPlayer,
+        &previous.media_player,
+        &next.media_player,
+    );
+    mark_if_changed(
+        &mut impact,
+        ModuleName::KeyboardLayout,
+        &previous.keyboard_layout,
+        &next.keyboard_layout,
+    );
+
+    if previous.custom_modules != next.custom_modules {
+        impact.custom_modules_changed = true;
+        update_custom_module_impact(&mut impact, &previous.custom_modules, &next.custom_modules);
+    }
+
+    impact
+}
+
+fn mark_if_changed<T>(impact: &mut ConfigImpact, module: ModuleName, previous: &T, next: &T)
+where
+    T: PartialEq,
+{
+    if previous != next {
+        impact.affected_modules.insert(module);
+    }
+}
+
+fn update_custom_module_impact(
+    impact: &mut ConfigImpact,
+    previous: &[CustomModuleDef],
+    next: &[CustomModuleDef],
+) {
+    let previous_map: HashMap<&str, &CustomModuleDef> = previous
+        .iter()
+        .map(|module| (module.name.as_str(), module))
+        .collect();
+    let next_map: HashMap<&str, &CustomModuleDef> = next
+        .iter()
+        .map(|module| (module.name.as_str(), module))
+        .collect();
+
+    for (name, module) in &next_map {
+        let needs_update = match previous_map.get(name) {
+            Some(current) => *current != *module,
+            None => true,
+        };
+
+        if needs_update {
+            impact
+                .affected_modules
+                .insert(ModuleName::Custom((*name).to_string()));
+        }
+    }
+
+    for name in previous_map.keys() {
+        if !next_map.contains_key(name) {
+            impact
+                .affected_modules
+                .insert(ModuleName::Custom((*name).to_string()));
+        }
+    }
+}

--- a/crates/hydebar-core/src/config/watch.rs
+++ b/crates/hydebar-core/src/config/watch.rs
@@ -1,0 +1,428 @@
+use std::any::TypeId;
+use std::ffi::{OsStr, OsString};
+use std::fmt::Display;
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::Arc;
+
+use iced::futures::channel::mpsc::{SendError, Sender};
+use iced::futures::pin_mut;
+use iced::futures::{SinkExt, Stream, StreamExt};
+use iced::{Subscription, stream::channel};
+use inotify::{EventMask, Inotify, WatchMask};
+use log::{debug, error, info, warn};
+
+use super::{ConfigReadError, read_config};
+use crate::config::manager::{ConfigApplied, ConfigDegradation, ConfigManager, ConfigUpdateError};
+
+/// Events produced by the configuration watcher subscription.
+#[derive(Debug, Clone)]
+pub enum ConfigEvent {
+    /// A new, validated configuration was applied.
+    Applied(ConfigApplied),
+    /// The configuration could not be refreshed and the previous state is retained.
+    Degraded(ConfigDegradation),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Event {
+    Changed,
+    Removed,
+}
+
+trait WatchedEvent {
+    fn file_name(&self) -> Option<&OsStr>;
+
+    fn mask(&self) -> EventMask;
+}
+
+impl WatchedEvent for inotify::Event<OsString> {
+    fn file_name(&self) -> Option<&OsStr> {
+        self.name.as_deref()
+    }
+
+    fn mask(&self) -> EventMask {
+        self.mask
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WatchLoopOutcome {
+    StreamEnded,
+    HandlerClosed,
+}
+
+fn interpret_event<E: WatchedEvent>(event: &E, target_name: &OsStr) -> Option<Event> {
+    let name = event.file_name()?;
+
+    if name != target_name {
+        return None;
+    }
+
+    let mask = event.mask();
+
+    let is_removed = mask.contains(EventMask::DELETE) || mask.contains(EventMask::MOVED_FROM);
+
+    if is_removed && !mask.intersects(EventMask::CREATE | EventMask::MODIFY | EventMask::MOVED_TO) {
+        debug!("File deleted or moved");
+        return Some(Event::Removed);
+    }
+
+    let is_changed = mask.intersects(
+        EventMask::CREATE | EventMask::MODIFY | EventMask::MOVED_TO | EventMask::CLOSE_WRITE,
+    );
+
+    if is_changed {
+        debug!("File changed");
+        Some(Event::Changed)
+    } else {
+        None
+    }
+}
+
+async fn process_event_batches<S, E, Err, F, Fut>(
+    mut stream: Pin<&mut S>,
+    target_name: &OsStr,
+    mut handler: F,
+) -> WatchLoopOutcome
+where
+    S: Stream<Item = Vec<Result<E, Err>>>,
+    E: WatchedEvent + std::fmt::Debug,
+    Err: Display,
+    F: FnMut(Event) -> Fut,
+    Fut: Future<Output = Result<(), SendError>>,
+{
+    while let Some(batch) = stream.as_mut().next().await {
+        let mut file_event = None;
+
+        for event in batch {
+            match event {
+                Ok(event) => {
+                    debug!("Event: {event:?}");
+
+                    match interpret_event(&event, target_name) {
+                        Some(kind) => {
+                            file_event = Some(kind);
+                        }
+                        None => {
+                            debug!("Ignoring event");
+                        }
+                    }
+                }
+                Err(err) => {
+                    error!("Failed to read watch event: {err}");
+                }
+            }
+        }
+
+        if let Some(kind) = file_event {
+            if let Err(err) = handler(kind).await {
+                warn!("Stopping config watch because handler returned an error: {err}");
+                return WatchLoopOutcome::HandlerClosed;
+            }
+        } else {
+            debug!("No relevant file event detected.");
+        }
+    }
+
+    WatchLoopOutcome::StreamEnded
+}
+
+async fn handle_watch_event(
+    output: &mut Sender<ConfigEvent>,
+    path: &Path,
+    event: Event,
+    manager: Arc<ConfigManager>,
+) -> Result<(), SendError> {
+    match event {
+        Event::Changed => {
+            info!("Reload config file");
+
+            match load_candidate(path, &manager) {
+                Ok(applied) => output.send(ConfigEvent::Applied(applied)).await,
+                Err(reason) => {
+                    warn!("Configuration update failed: {reason}");
+                    send_degradation(output, manager, reason).await
+                }
+            }
+        }
+        Event::Removed => {
+            info!("Config file removed");
+
+            send_degradation(output, manager, ConfigUpdateError::Removed).await
+        }
+    }
+}
+
+fn load_candidate(
+    path: &Path,
+    manager: &ConfigManager,
+) -> Result<ConfigApplied, ConfigUpdateError> {
+    let config = read_config(path).map_err(convert_read_error)?;
+
+    config.validate()?;
+
+    manager
+        .apply(config)
+        .map_err(|err| ConfigUpdateError::state(err.to_string()))
+}
+
+fn convert_read_error(err: ConfigReadError) -> ConfigUpdateError {
+    match err {
+        ConfigReadError::Read { path, source } => ConfigUpdateError::read(path, &source),
+        ConfigReadError::Parse { path, source } => ConfigUpdateError::parse(path, &source),
+    }
+}
+
+async fn send_degradation(
+    output: &mut Sender<ConfigEvent>,
+    manager: Arc<ConfigManager>,
+    reason: ConfigUpdateError,
+) -> Result<(), SendError> {
+    match manager.degraded(reason) {
+        Ok(degradation) => output.send(ConfigEvent::Degraded(degradation)).await,
+        Err(err) => {
+            error!("Failed to report configuration degradation: {err}");
+            Ok(())
+        }
+    }
+}
+
+pub fn subscription(path: &Path, manager: Arc<ConfigManager>) -> Subscription<ConfigEvent> {
+    let id = TypeId::of::<ConfigEvent>();
+    let path = path.to_path_buf();
+
+    Subscription::run_with_id(
+        id,
+        channel(100, move |mut output| {
+            let manager = Arc::clone(&manager);
+
+            async move {
+                let Some(folder) = path.parent().map(Path::to_path_buf) else {
+                    error!(
+                        "Config file path does not have a parent directory, cannot watch for changes"
+                    );
+                    return;
+                };
+
+                let Some(file_name) = path.file_name().map(OsStr::to_os_string) else {
+                    error!("Config file path does not have a file name, cannot watch for changes");
+                    return;
+                };
+
+                loop {
+                    let inotify = match Inotify::init() {
+                        Ok(inotify) => inotify,
+                        Err(e) => {
+                            error!("Failed to initialize inotify: {e}");
+                            break;
+                        }
+                    };
+
+                    debug!("Watching config file at {path:?}");
+
+                    let watch_result = inotify.watches().add(
+                        &folder,
+                        WatchMask::CREATE | WatchMask::DELETE | WatchMask::MOVE | WatchMask::MODIFY,
+                    );
+
+                    if let Err(e) = watch_result {
+                        error!("Failed to add watch for {folder:?}: {e}");
+                        break;
+                    }
+
+                    let buffer = [0; 1024];
+                    let stream = match inotify.into_event_stream(buffer) {
+                        Ok(stream) => stream,
+                        Err(e) => {
+                            error!("Failed to create inotify event stream: {e}");
+                            break;
+                        }
+                    };
+
+                    let event_stream = stream.ready_chunks(10);
+                    pin_mut!(event_stream);
+
+                    let sender_template = output.clone();
+                    let path_clone = path.clone();
+                    let manager_clone = Arc::clone(&manager);
+
+                    match process_event_batches(
+                        event_stream.as_mut(),
+                        file_name.as_os_str(),
+                        move |event| {
+                            let mut sender = sender_template.clone();
+                            let path = path_clone.clone();
+                            let manager = Arc::clone(&manager_clone);
+
+                            async move { handle_watch_event(&mut sender, &path, event, manager).await }
+                        },
+                    )
+                    .await
+                    {
+                        WatchLoopOutcome::StreamEnded => {
+                            info!(
+                                "Config watch stream closed; attempting to restart the inotify watcher"
+                            );
+                            continue;
+                        }
+                        WatchLoopOutcome::HandlerClosed => {
+                            info!("Config watch handler closed; stopping watcher loop");
+                            break;
+                        }
+                    }
+                }
+
+                info!("Config watcher terminated");
+            }
+        }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::manager::ConfigManager;
+    use hydebar_proto::config::Config;
+    use iced::futures::channel::mpsc;
+    use std::ffi::{OsStr, OsString};
+    use tempfile::TempDir;
+
+    #[derive(Debug)]
+    struct FakeEvent {
+        name: Option<OsString>,
+        mask: EventMask,
+    }
+
+    impl WatchedEvent for FakeEvent {
+        fn file_name(&self) -> Option<&OsStr> {
+            self.name.as_deref()
+        }
+
+        fn mask(&self) -> EventMask {
+            self.mask
+        }
+    }
+
+    #[test]
+    fn interpret_event_detects_removed_events() {
+        let target = OsStr::new("config.toml");
+
+        let delete_event = FakeEvent {
+            name: Some(OsString::from("config.toml")),
+            mask: EventMask::DELETE,
+        };
+        assert_eq!(interpret_event(&delete_event, target), Some(Event::Removed));
+
+        let moved_from_event = FakeEvent {
+            name: Some(OsString::from("config.toml")),
+            mask: EventMask::MOVED_FROM,
+        };
+        assert_eq!(
+            interpret_event(&moved_from_event, target),
+            Some(Event::Removed)
+        );
+
+        let unrelated_name = FakeEvent {
+            name: Some(OsString::from("other.toml")),
+            mask: EventMask::DELETE,
+        };
+        assert_eq!(interpret_event(&unrelated_name, target), None);
+    }
+
+    #[test]
+    fn interpret_event_detects_changed_events() {
+        let target = OsStr::new("config.toml");
+
+        for mask in [
+            EventMask::CREATE,
+            EventMask::MODIFY,
+            EventMask::MOVED_TO,
+            EventMask::CLOSE_WRITE,
+        ] {
+            let event = FakeEvent {
+                name: Some(OsString::from("config.toml")),
+                mask,
+            };
+            assert_eq!(interpret_event(&event, target), Some(Event::Changed));
+        }
+
+        let ignored_event = FakeEvent {
+            name: Some(OsString::from("config.toml")),
+            mask: EventMask::ACCESS,
+        };
+        assert_eq!(interpret_event(&ignored_event, target), None);
+    }
+
+    #[tokio::test]
+    async fn emits_applied_event_for_valid_update() {
+        let temp_dir = TempDir::new().expect("failed to create temp dir");
+        let config_path = temp_dir.path().join("config.toml");
+        std::fs::write(&config_path, "").expect("failed to write config");
+
+        let manager = Arc::new(ConfigManager::new(Config::default()));
+        let (mut sender, mut receiver) = mpsc::channel(10);
+
+        handle_watch_event(
+            &mut sender,
+            &config_path,
+            Event::Changed,
+            Arc::clone(&manager),
+        )
+        .await
+        .expect("sending event should succeed");
+
+        match receiver.next().await {
+            Some(ConfigEvent::Applied(_)) => {}
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn emits_degraded_event_for_invalid_toml() {
+        let temp_dir = TempDir::new().expect("failed to create temp dir");
+        let config_path = temp_dir.path().join("config.toml");
+        std::fs::write(&config_path, "invalid = [").expect("failed to write invalid config");
+
+        let manager = Arc::new(ConfigManager::new(Config::default()));
+        let (mut sender, mut receiver) = mpsc::channel(10);
+
+        handle_watch_event(
+            &mut sender,
+            &config_path,
+            Event::Changed,
+            Arc::clone(&manager),
+        )
+        .await
+        .expect("sending event should succeed");
+
+        match receiver.next().await {
+            Some(ConfigEvent::Degraded(event)) => {
+                assert!(matches!(event.reason, ConfigUpdateError::Parse { .. }));
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn emits_degraded_event_when_file_removed() {
+        let temp_dir = TempDir::new().expect("failed to create temp dir");
+        let config_path = temp_dir.path().join("config.toml");
+        std::fs::write(&config_path, "").expect("failed to write config");
+
+        let manager = Arc::new(ConfigManager::new(Config::default()));
+        let (mut sender, mut receiver) = mpsc::channel(10);
+
+        handle_watch_event(&mut sender, &config_path, Event::Removed, manager)
+            .await
+            .expect("sending event should succeed");
+
+        match receiver.next().await {
+            Some(ConfigEvent::Degraded(event)) => {
+                assert!(matches!(event.reason, ConfigUpdateError::Removed));
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a `ConfigManager` that keeps the last valid configuration, computes module-level impact, and emits degradation events instead of resetting to defaults
- validate custom module definitions and move the watcher logic into a dedicated module that loads and verifies config updates before publishing them
- update the GUI to consume partial config updates, refresh only affected modules, and extend watcher and validation tests accordingly

## Testing
- `cargo +nightly fmt --`
- `cargo +1.90.0 clippy -- -D warnings`
- `cargo +1.90.0 build --all-targets` *(fails: missing system library `xkbcommon`)*
- `cargo +1.90.0 test --all` *(fails: missing system library `xkbcommon`)*
- `cargo audit`
- `cargo deny check` *(fails: cannot fetch advisory database)*

------
https://chatgpt.com/codex/tasks/task_e_68d66809f928832bac14b9fcf11f061f